### PR TITLE
#21 [feat] googleSpreadSheet 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dist
 
 #보안관련해서..
 package-lock.json
+
+
+compact-medium-411614-3a73ec5b154b.json

--- a/api/controllers/sessionController.js
+++ b/api/controllers/sessionController.js
@@ -2,6 +2,8 @@ const Session = require('../models/session');
 const Attend = require('../models/attend');
 const User = require('../models/user');
 const AttendanceTokenCache = require('../cache/token');
+const { google } = require('googleapis');
+require('dotenv').config();
 
 // 세션 만들기  
 exports.createSession = async (req, res) => {
@@ -266,5 +268,260 @@ exports.getSessionById = async (req, res) => {
     res.status(200).send({ session, attends });
   } catch (error) {
     res.status(500).send({ message: "세션을 가져오는 중 오류가 발생했습니다", error });
+  }
+};
+
+const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
+const KEYFILE_PATH = process.env.KEYFILE_PATH;
+
+const auth = new google.auth.GoogleAuth({
+    keyFile: KEYFILE_PATH,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets']
+});
+
+const sheets = google.sheets({ version: 'v4', auth });
+
+exports.spreadsheets = async (req, res) => {
+  try {
+    // 세션 데이터 가져오기
+    const sessions = await Session.find({});
+
+    // 세션 데이터를 가로로 배열 형식으로 변환
+    const columns = [
+      ...sessions.map(session => [
+        session.name + "1st",
+        session.name + "2nd",
+        session.name + "3rd"
+      ]).flat()
+    ];
+
+    // 스프레드시트에 데이터를 추가
+    const response = await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: 'Sheet1!B1', // 데이터를 추가할 범위 설정
+      valueInputOption: 'RAW',
+      resource: {
+        values: [columns]
+      }
+    });
+
+    res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
+  }
+};
+
+
+function getColumnLetter(colIndex) {
+  let temp, letter = '';
+  while (colIndex > 0) {
+    temp = (colIndex - 1) % 26;
+    letter = String.fromCharCode(temp + 65) + letter;
+    colIndex = (colIndex - temp - 1) / 26;
+  }
+  return letter;
+}
+
+
+exports.sessionToSpreadsheet = async (req, res) => {
+  try {
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    const { id } = req.params;
+    const session = await Session.findById(id);
+    if (!session) {
+      return res.status(404).send({ message: "세션을 찾을 수 없습니다" });
+    }
+
+    const attends = await Attend.find({ session: session._id });
+
+    // 출석 정보를 배열 형식으로 변환
+    const rows = attends.map(attend => [
+      ...attend.attendList.map(a => a.status)
+    ]);
+
+    // 스프레드시트의 데이터 읽어오기
+    const range = 'Sheet1!2:2'; 
+    const getResponse = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: range,
+    });
+
+    // 첫 번째 빈 셀 찾기
+    const rowValues = getResponse.data.values ? getResponse.data.values[0] : [];
+    let emptyColumnIndex = rowValues.length + 1; 
+
+    // 아스키코드로 열 이름 계산 (A부터 시작)
+    const nextColumnLetter = getColumnLetter(emptyColumnIndex);
+
+    // 데이터 추가 범위 설정
+    const targetRange = `Sheet1!${nextColumnLetter}2`;
+
+    // 스프레드시트에 데이터를 추가
+    const appendResponse = await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: targetRange,
+      valueInputOption: 'RAW',
+      resource: {
+        values: rows
+      }
+    });
+
+    res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
+  }
+};
+
+exports.firstSessionToSpreadsheet = async (req, res) => {
+  try {
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    const { id } = req.params;
+    const session = await Session.findById(id);
+    if (!session) {
+      return res.status(404).send({ message: "세션을 찾을 수 없습니다" });
+    }
+
+    const attends = await Attend.find({ session: session._id });
+
+    // 출석 정보를 배열 형식으로 변환
+    const rows = attends.map(attend => [
+      attend.attendList[0].status
+    ]);
+
+    // 스프레드시트의 데이터 읽어오기
+    const range = 'Sheet1!2:2'; 
+    const getResponse = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: range,
+    });
+
+    // 첫 번째 빈 셀 찾기
+    const rowValues = getResponse.data.values ? getResponse.data.values[0] : [];
+    let emptyColumnIndex = rowValues.length + 1; 
+
+    // 아스키코드로 열 이름 계산 (A부터 시작)
+    const nextColumnLetter = getColumnLetter(emptyColumnIndex);
+
+    // 데이터 추가 범위 설정
+    const targetRange = `Sheet1!${nextColumnLetter}2`;
+
+    // 스프레드시트에 데이터를 추가
+    const appendResponse = await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: targetRange,
+      valueInputOption: 'RAW',
+      resource: {
+        values: rows
+      }
+    });
+
+    res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
+  }
+};
+exports.secondSessionToSpreadsheet = async (req, res) => {
+  try {
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    const { id } = req.params;
+    const session = await Session.findById(id);
+    if (!session) {
+      return res.status(404).send({ message: "세션을 찾을 수 없습니다" });
+    }
+
+    const attends = await Attend.find({ session: session._id });
+
+    // 출석 정보를 배열 형식으로 변환
+    const rows = attends.map(attend => [
+      attend.attendList[1].status
+    ]);
+
+    // 스프레드시트의 데이터 읽어오기
+    const range = 'Sheet1!2:2'; 
+    const getResponse = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: range,
+    });
+
+    // 첫 번째 빈 셀 찾기
+    const rowValues = getResponse.data.values ? getResponse.data.values[0] : [];
+    let emptyColumnIndex = rowValues.length + 1; 
+
+    // 아스키코드로 열 이름 계산 (A부터 시작)
+    const nextColumnLetter = getColumnLetter(emptyColumnIndex);
+
+    // 데이터 추가 범위 설정
+    const targetRange = `Sheet1!${nextColumnLetter}2`;
+
+    // 스프레드시트에 데이터를 추가
+    const appendResponse = await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: targetRange,
+      valueInputOption: 'RAW',
+      resource: {
+        values: rows
+      }
+    });
+
+    res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
+  }
+};
+exports.thirdSessionToSpreadsheet = async (req, res) => {
+  try {
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    const { id } = req.params;
+    const session = await Session.findById(id);
+    if (!session) {
+      return res.status(404).send({ message: "세션을 찾을 수 없습니다" });
+    }
+
+    const attends = await Attend.find({ session: session._id });
+
+    // 출석 정보를 배열 형식으로 변환
+    const rows = attends.map(attend => [
+      attend.attendList[2].status
+    ]);
+
+    // 스프레드시트의 데이터 읽어오기
+    const range = 'Sheet1!2:2'; 
+    const getResponse = await sheets.spreadsheets.values.get({
+      spreadsheetId: SPREADSHEET_ID,
+      range: range,
+    });
+
+    // 첫 번째 빈 셀 찾기
+    const rowValues = getResponse.data.values ? getResponse.data.values[0] : [];
+    let emptyColumnIndex = rowValues.length + 1; 
+
+    // 아스키코드로 열 이름 계산 (A부터 시작)
+    const nextColumnLetter = getColumnLetter(emptyColumnIndex);
+
+    // 데이터 추가 범위 설정
+    const targetRange = `Sheet1!${nextColumnLetter}2`;
+
+    // 스프레드시트에 데이터를 추가
+    const appendResponse = await sheets.spreadsheets.values.append({
+      spreadsheetId: SPREADSHEET_ID,
+      range: targetRange,
+      valueInputOption: 'RAW',
+      resource: {
+        values: rows
+      }
+    });
+
+    res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
   }
 };

--- a/api/controllers/userController.js
+++ b/api/controllers/userController.js
@@ -4,6 +4,9 @@ const Session = require('../models/session')
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 
+const { google } = require('googleapis');
+require('dotenv').config();
+
 // JWT 비밀키
 const JWT_SECRET = "piro";
 
@@ -202,8 +205,41 @@ exports.updateUserAttendance =  async (req, res) => {
       // DB에 업데이트
       await attendance.save();
 
-      res.status(200).json({ message: 'Attendance updated successfully', attendance });
+      res.status(200).send('성공적으로 데이터를 옮겼습니다.');
   } catch (error) {
-      res.status(500).json({ message: 'Server error', error });
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
+  }
+};
+
+const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
+const KEYFILE_PATH = process.env.KEYFILE_PATH;
+
+const auth = new google.auth.GoogleAuth({
+    keyFile: KEYFILE_PATH,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets']
+});
+
+const sheets = google.sheets({ version: 'v4', auth });
+
+exports.spreadsheets = async (req, res) => {
+  try {
+      const sheets = google.sheets({ version: 'v4', auth });
+      
+      const users = await User.find({}, 'username');
+      const values = users.map(user => [user.username]);
+      
+      const response = await sheets.spreadsheets.values.append({
+          spreadsheetId: SPREADSHEET_ID,
+          range: 'Sheet1!A2', // 데이터를 추가할 범위를 설정하세요.
+          valueInputOption: 'RAW',
+          resource: {
+              values
+          }
+      });
+      res.status(200).send('성공적으로 데이터를 옮겼습니다.');
+  } catch (error) {
+    console.error('데이터를 옮기는데 실패했습니다', error);
+    res.status(500).send('데이터를 옮기는데 실패했습니다');
   }
 };

--- a/api/routers/sessionRouters.js
+++ b/api/routers/sessionRouters.js
@@ -33,7 +33,11 @@ router.delete('/endAttendCheck',authenticateToken,adminMiddleware, sessionContro
 
 // 세션 삭제 (어드민 인증 필요)
 router.delete('/deleteSession/:sessionId', authenticateToken, adminMiddleware, sessionController.deleteSession);
-
+router.get('/attendance/spreadsheets', authenticateToken,adminMiddleware, sessionController.spreadsheets);
+router.post('/sessions/:id/spreadsheets', authenticateToken,adminMiddleware,sessionController.sessionToSpreadsheet);
+router.post('/sessions/:id/spreadsheets/1', authenticateToken,adminMiddleware,sessionController.firstSessionToSpreadsheet);
+router.post('/sessions/:id/spreadsheets/2', authenticateToken,adminMiddleware,sessionController.secondSessionToSpreadsheet);
+router.post('/sessions/:id/spreadsheets/3', authenticateToken,adminMiddleware,sessionController.thirdSessionToSpreadsheet);
 module.exports = router;
 
 /**
@@ -47,6 +51,90 @@ module.exports = router;
 
 /**
  * @swagger
+ * /api/session/sessions/{id}/spreadsheets:
+ *   post:
+ *     summary: "특정 세션의 출석 정보를 Google 스프레드시트로 내보냅니다"
+ *     tags: [Sessions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: "id"
+ *         in: "path"
+ *         required: true
+ *         schema:
+ *           type: "string"
+ *         description: "세션 ID"
+ *     responses:
+ *       200:
+ *         description: "성공적으로 출석 데이터를 내보냈습니다"
+ *       404:
+ *         description: "세션을 찾을 수 없습니다"
+ *       500:
+ *         description: "출석 데이터를 내보내는 중 오류가 발생했습니다"
+ * 
+ * /api/session/sessions/{id}/spreadsheets/1:
+ *   post:
+ *     summary: "특정 세션의 출석 정보를 Google 스프레드시트로 내보냅니다"
+ *     tags: [Sessions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: "id"
+ *         in: "path"
+ *         required: true
+ *         schema:
+ *           type: "string"
+ *         description: "세션 ID"
+ *     responses:
+ *       200:
+ *         description: "성공적으로 출석 데이터를 내보냈습니다"
+ *       404:
+ *         description: "세션을 찾을 수 없습니다"
+ *       500:
+ *         description: "출석 데이터를 내보내는 중 오류가 발생했습니다"
+ * 
+ * /api/session/sessions/{id}/spreadsheets/2:
+ *   post:
+ *     summary: "특정 세션의 출석 정보를 Google 스프레드시트로 내보냅니다"
+ *     tags: [Sessions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: "id"
+ *         in: "path"
+ *         required: true
+ *         schema:
+ *           type: "string"
+ *         description: "세션 ID"
+ *     responses:
+ *       200:
+ *         description: "성공적으로 출석 데이터를 내보냈습니다"
+ *       404:
+ *         description: "세션을 찾을 수 없습니다"
+ *       500:
+ *         description: "출석 데이터를 내보내는 중 오류가 발생했습니다"
+ * 
+ * /api/session/sessions/{id}/spreadsheets/3:
+ *   post:
+ *     summary: "특정 세션의 출석 정보를 Google 스프레드시트로 내보냅니다"
+ *     tags: [Sessions]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: "id"
+ *         in: "path"
+ *         required: true
+ *         schema:
+ *           type: "string"
+ *         description: "세션 ID"
+ *     responses:
+ *       200:
+ *         description: "성공적으로 출석 데이터를 내보냈습니다"
+ *       404:
+ *         description: "세션을 찾을 수 없습니다"
+ *       500:
+ *         description: "출석 데이터를 내보내는 중 오류가 발생했습니다"
+ * 
  * /api/session/createSession:
  *   post:
  *     summary: 새로운 세션 생성
@@ -313,6 +401,19 @@ module.exports = router;
  *                   example: "출석 체크가 진행 중이 아닙니다."
  *       500:
  *         description: 서버 오류
+ * /api/session/attendance/spreadsheets:
+ *   get:
+ *     summary: Record attendance data to Google Sheets
+ *     description: Records attendance data to a specified Google Spreadsheet. Requires authentication and admin privileges.
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Attendance
+ *     responses:
+ *       200:
+ *         description: Attendance recorded successfully
+ *       500:
+ *         description: Error recording attendance
  */
 
 /**

--- a/api/routers/userRouters.js
+++ b/api/routers/userRouters.js
@@ -29,6 +29,8 @@ router.post('/signup/send', emailConfig.sendEmail);
 router.post('/signup/cert', emailConfig.certEmail);
 // 출석 정보 확인 edited by 진혁
 router.get('/checkAttendance/:id', authenticateToken, userController.checkAttendance);
+
+router.post('/users/spreadsheets', authenticateToken, adminMiddleware, userController.spreadsheets);
 module.exports = router;
 /**
  * @swagger
@@ -112,7 +114,19 @@ module.exports = router;
  *          description: "인증 실패"
  *        500:
  *          description: "서버 오류"
- *  
+ *  /api/user/users/spreadsheets:
+ *   post:
+ *     summary: Record usernames to Google Sheets
+ *     description: Retrieve all users' usernames and record them to a specified Google Spreadsheet. Requires authentication and admin privileges.
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Usernames recorded successfully
+ *       500:
+ *         description: Error recording usernames
+ *
  *  /api/user/users:
  *    get:
  *      summary: "모든 유저 조회"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "googleapis": "^140.0.1",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.6.2",
     "mongoose": "^8.3.4",

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -11,7 +11,7 @@ const options = {
     },
     servers: [
       {
-        url: "https://piro-recruiting.top", // Adjust this to your server address
+        url: "http://localhost:3000", // Adjust this to your server address
         description: "api server",
       },
     ],


### PR DESCRIPTION
서버에서 바로 모든 출석 정보를 넘길 수 있도록 변경

모든 유저 정보 가져오는 api( /api/user/users/spreadsheets )
모든 세션 정보 가져오기 ( /api/session/attendance/spreadsheets )
하루의 모든 출석 기록 가져오는 api(3번의 출석 모두) ( /api/session/sessions/:id/spreadsheets )
하루의 출석 중 첫번째 출석 기록 가져오는 api ( /api/session/attendance/spreadsheets/1 )
하루의 출석 중 두번째 출석 기록 가져오는 api ( /api/session/attendance/spreadsheets/2 )
하루의 출석 중 세번째 출석 기록 가져오는 api ( /api/session/attendance/spreadsheets/3 )